### PR TITLE
Added SetPreferredLanguages to WebContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Go template
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+
+.idea/
+
+*.iml

--- a/webkit2/arrays.h
+++ b/webkit2/arrays.h
@@ -1,0 +1,33 @@
+#ifndef GO_ARRAYS_H
+#define GO_ARRAYS_H
+
+#include <stdlib.h>
+
+static gchar** alloc_gchar_array(size_t l)
+{
+	gchar**	v;
+
+	v = calloc(l, sizeof(gchar*));
+	return v;
+}
+
+static void free_gchar_array(gchar** v)
+{
+	int	i;
+
+	if (v == NULL) {
+		return;
+	}
+
+	for (i = 0; v[i] != NULL; ++i) {
+		free(v[i]);
+	}
+	free(v);
+}
+
+static void set_gchar_array(gchar** v, int i, gchar* s)
+{
+	v[i] = s;
+}
+
+#endif

--- a/webkit2/webcontext.go
+++ b/webkit2/webcontext.go
@@ -1,6 +1,7 @@
 package webkit2
 
 // #include <webkit2/webkit2.h>
+// #include "arrays.h"
 import "C"
 
 // WebContext manages all aspects common to all WebViews.
@@ -55,4 +56,33 @@ func (wc *WebContext) SetCacheModel(model CacheModel) {
 // http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebContext.html#webkit-web-context-clear-cache.
 func (wc *WebContext) ClearCache() {
 	C.webkit_web_context_clear_cache(wc.webContext)
+}
+
+// SetPreferredLanguages set the list of preferred languages, sorted from most desirable to least desirable.
+//
+// See also: webkit_web_context_set_preferred_languages at
+// http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebContext.html#webkit-web-context-set-preferred-languages.
+func (wc *WebContext) SetPreferredLanguages(languages []string) {
+	clang := C.alloc_gchar_array((C.size_t)(len(languages) + 1))
+
+
+	//defer C.free_gchar_array(clang)
+
+	cstrs := make([]*C.char, len(languages))
+	/*
+	defer func() {
+		for _, cstr := range cstrs {
+			C.free(unsafe.Pointer(cstr))
+		}
+	}()
+*/
+	for i, s := range languages {
+		cstr := C.CString(s)
+		cstrs[i] = cstr
+		C.set_gchar_array(clang, C.int(i), (*C.gchar)(cstr))
+	}
+
+	C.set_gchar_array(clang, C.int(len(languages)), (*C.gchar)(nil))
+
+	C.webkit_web_context_set_preferred_languages(wc.webContext, clang)
 }

--- a/webkit2/webcontext.go
+++ b/webkit2/webcontext.go
@@ -3,10 +3,7 @@ package webkit2
 // #include <webkit2/webkit2.h>
 // #include "arrays.h"
 import "C"
-import (
-	"unsafe"
-	"runtime"
-)
+import "runtime"
 
 // WebContext manages all aspects common to all WebViews.
 //
@@ -17,7 +14,6 @@ type WebContext struct {
 
 	// Book keeping for the C allocations
 	languageGCharArray **C.gchar
-	languageCStrs      []*C.char
 }
 
 // DefaultWebContext returns the default WebContext.
@@ -76,12 +72,9 @@ func (wc *WebContext) SetPreferredLanguages(languages []string) {
 	wc.freeLanguageGCharArray()
 	wc.languageGCharArray = C.alloc_gchar_array((C.size_t)(len(languages) + 1))
 
-	wc.freeLanguageCStrs()
-	wc.languageCStrs = make([]*C.char, len(languages))
 
 	for i, s := range languages {
 		cstr := C.CString(s)
-		wc.languageCStrs[i] = cstr
 		C.set_gchar_array(wc.languageGCharArray, C.int(i), (*C.gchar)(cstr))
 	}
 
@@ -92,7 +85,6 @@ func (wc *WebContext) SetPreferredLanguages(languages []string) {
 
 func (wc *WebContext) Free() {
 	wc.freeLanguageGCharArray()
-	wc.freeLanguageCStrs()
 }
 
 func (wc *WebContext) freeLanguageGCharArray() {
@@ -104,14 +96,3 @@ func (wc *WebContext) freeLanguageGCharArray() {
 	wc.languageGCharArray = nil
 }
 
-func (wc *WebContext) freeLanguageCStrs() {
-	if wc.languageCStrs == nil {
-		return
-	}
-
-	for _, cstr := range wc.languageCStrs {
-		C.free(unsafe.Pointer(cstr))
-	}
-
-	wc.languageCStrs = nil
-}

--- a/webkit2/webcontext.go
+++ b/webkit2/webcontext.go
@@ -21,7 +21,7 @@ type WebContext struct {
 // See also: webkit_web_context_get_default at
 // http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebContext.html#webkit-web-context-get-default.
 func DefaultWebContext() *WebContext {
-	wc := &WebContext{C.webkit_web_context_get_default(), nil, nil}
+	wc := &WebContext{C.webkit_web_context_get_default(), nil}
 	runtime.SetFinalizer(wc, (*WebContext).Free)
 	return wc
 }

--- a/webkit2/webcontext.go
+++ b/webkit2/webcontext.go
@@ -16,7 +16,7 @@ type WebContext struct {
 	webContext *C.WebKitWebContext
 
 	// Book keeping for the C allocations
-	languageGCharArray int
+	languageGCharArray **C.gchar
 	languageCStrs      []*C.char
 }
 
@@ -25,7 +25,7 @@ type WebContext struct {
 // See also: webkit_web_context_get_default at
 // http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebContext.html#webkit-web-context-get-default.
 func DefaultWebContext() *WebContext {
-	wc := &WebContext{C.webkit_web_context_get_default()}
+	wc := &WebContext{C.webkit_web_context_get_default(), nil, nil}
 	runtime.SetFinalizer(wc, (*WebContext).Free)
 	return wc
 }

--- a/webkit2/webview.go
+++ b/webkit2/webview.go
@@ -85,7 +85,7 @@ func newWebView(webViewWidget *C.GtkWidget) *WebView {
 // See also: webkit_web_view_get_context at
 // http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#webkit-web-view-get-context.
 func (v *WebView) Context() *WebContext {
-	return &WebContext{C.webkit_web_view_get_context(v.webView), nil, nil}
+	return &WebContext{C.webkit_web_view_get_context(v.webView), nil}
 }
 
 // LoadURI requests loading of the specified URI string.

--- a/webkit2/webview.go
+++ b/webkit2/webview.go
@@ -85,7 +85,7 @@ func newWebView(webViewWidget *C.GtkWidget) *WebView {
 // See also: webkit_web_view_get_context at
 // http://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebView.html#webkit-web-view-get-context.
 func (v *WebView) Context() *WebContext {
-	return &WebContext{C.webkit_web_view_get_context(v.webView)}
+	return &WebContext{C.webkit_web_view_get_context(v.webView), nil, nil}
 }
 
 // LoadURI requests loading of the specified URI string.


### PR DESCRIPTION
Currently there is no way to set the `navigator.language` and the `Accept-Language` of the HTTP header for the WebKit instance. 

This patch exposes the function call `webkit_web_context_set_preferred_languages` on `WebContext` and adds the required cleanup.
